### PR TITLE
Fix userId is null on history validation by ModuleRegistration

### DIFF
--- a/src/Validation/Validator/PasswordHistory.php
+++ b/src/Validation/Validator/PasswordHistory.php
@@ -40,6 +40,10 @@ final class PasswordHistory implements PasswordValidatorInterface
             return true;
         }
 
+        if(null === $context->getUserId()) {
+            return true;
+        }
+        
         $configuration = $this->configuration->getConfiguration($context->getUserEntity());
         $historyLength = $configuration['password_history'];
         if (!$historyLength) {

--- a/src/Validation/Validator/PasswordHistory.php
+++ b/src/Validation/Validator/PasswordHistory.php
@@ -40,7 +40,7 @@ final class PasswordHistory implements PasswordValidatorInterface
             return true;
         }
 
-        if(null === $context->getUserId()) {
+        if (null === $context->getUserId()) {
             return true;
         }
         


### PR DESCRIPTION
userId ist set to null if validation is called from ModuleRegistration
This will then throw an exception in `PasswordHistoryModel::findHistory($userEntity, $userId, $historyLength);` -> https://github.com/terminal42/contao-password-validation/blob/master/src/Validation/Validator/PasswordHistory.php#L53

So this is my preferred fix option for the case "Validate password on ModuleRegistration events with configured pasword history as validator": 
Don't write a password history entry with userid null.